### PR TITLE
Improve compile time and introduce features

### DIFF
--- a/x11-keysymdef/Cargo.toml
+++ b/x11-keysymdef/Cargo.toml
@@ -14,3 +14,9 @@ lazy_static = "1.3.0"
 [build-dependencies]
 serde_json = "1.0.40"
 serde = { version = "1.0.97", features = ["derive"] }
+
+[features]
+default = ["by_name", "by_codepoint", "by_keysym" ]
+by_name = []
+by_codepoint = []
+by_keysym = []

--- a/x11-keysymdef/src/lib.rs
+++ b/x11-keysymdef/src/lib.rs
@@ -11,23 +11,29 @@
 include!(concat!(env!("OUT_DIR"), "/mapping.rs"));
 
 /// Look up a record by the mnemonic macro name
+#[cfg(feature = "by_name")]
 pub fn lookup_by_name(name: &str) -> Option<&'static Record> {
     BY_NAMES.get(&name).copied()
 }
 
 /// Look up a record by unicode char (unicode code point)
+#[cfg(feature = "by_codepoint")]
 pub fn lookup_by_codepoint(codepoint: char) -> Option<&'static Record> {
     BY_CODEPOINT.get(&codepoint).copied()
 }
 
 /// Look up a mnemonic macro name by the keysym code
+#[cfg(feature = "by_keysym")]
 pub fn lookup_by_keysym(keysym: u32) -> Option<&'static Record> {
     BY_KEYSYM.get(&keysym).copied()
 }
 
 #[test]
 fn access_works() {
+    #[cfg(feature = "by_name")]
     assert!(lookup_by_name("Uhorngrave").is_some());
+    #[cfg(feature = "by_codepoint")]
     assert!(lookup_by_codepoint('\u{1EEA}').is_some());
+    #[cfg(feature = "by_keysym")]
     assert!(lookup_by_keysym(0x1eea).is_some());
 }


### PR DESCRIPTION
This patch allows the different indexes to be toggled since they contribute significantly to compile time and for many applications not all three are needed. Additionally, the entry-or_insert pattern was replaced by building the HashMap from a slice, reducing the compile time even more.

**Behavioral Change**: If the index contains multiple entries with the same key, the last one is used instead of the first one. This is because the entries are consumed from a vec, which causes duplicated keys to be overwritten, instead of skipping them. If this is considered as a blocker for this PR, reversing the list of records before generating the code should resolve that. Since this scenario wasn't included in the tests and reversing the list could mean extra effort, I left that out for now.